### PR TITLE
Add page titles to all pages.

### DIFF
--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,0 +1,22 @@
+import Head from 'next/head';
+import React from 'react';
+
+const TITLE_PREFIX = 'LDaCA';
+
+type Props = {
+  pageTitle?: string;
+};
+
+const Title: React.FC<Props> = ({pageTitle}) => {
+  let title = TITLE_PREFIX;
+  if (pageTitle) {
+    title += ` - ${pageTitle}`;
+  }
+  return (
+    <Head>
+      <title>{title}</title>
+    </Head>
+  );
+};
+
+export default Title;

--- a/src/pages/[page].tsx
+++ b/src/pages/[page].tsx
@@ -1,6 +1,7 @@
 import MarkdownArticle from 'components/MarkdownContent';
+import Title from 'components/Title';
 import markdownToHtml from 'lib/markdownToHTML';
-import {getAllPageSlugs, getPageContent} from 'lib/pageMarkdown';
+import {getAllPageSlugs, getPageBySlug, getPageContent} from 'lib/pageMarkdown';
 import {getSearchContent} from 'lib/searchContent';
 import {useSearch} from 'lib/useSearch';
 import {GetStaticPaths, GetStaticProps} from 'next';
@@ -8,19 +9,27 @@ import React from 'react';
 import SearchContent from 'types/searchContent';
 
 type Props = {
+  title?: string;
   content: string;
   searchContent: SearchContent;
 };
 
-export default function ContentPage({content, searchContent}: Props) {
+export default function ContentPage({content, searchContent, title}: Props) {
   useSearch(searchContent);
-  return <MarkdownArticle content={content} />;
+  return (
+    <>
+      <Title pageTitle={title} />
+      <MarkdownArticle content={content} />;
+    </>
+  );
 }
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
+  const slug = (params?.page as string) ?? '';
+  const {title} = getPageBySlug(slug, ['title']);
   const content = await markdownToHtml(getPageContent(params?.page as string));
   const searchContent = getSearchContent();
-  return {props: {content, searchContent}};
+  return {props: {content, searchContent, title}};
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,4 +1,5 @@
 import MarkdownArticle from 'components/MarkdownContent';
+import Title from 'components/Title';
 import markdownToHtml from 'lib/markdownToHTML';
 import {getPageContent} from 'lib/pageMarkdown';
 import {getSearchContent} from 'lib/searchContent';
@@ -15,6 +16,7 @@ export default function Home({content, searchContent}: Props) {
   useSearch(searchContent);
   return (
     <>
+      <Title pageTitle="Contact Us" />
       <MarkdownArticle content={content} />
       <div className="mt-8">
         <TwitterTimelineEmbed

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -1,23 +1,24 @@
 import MarkdownArticle from 'components/MarkdownContent';
+import Title from 'components/Title';
 import markdownToHtml from 'lib/markdownToHTML';
 import {getAllPosts, getPostBySlug} from 'lib/postMarkdown';
 import {getSearchContent} from 'lib/searchContent';
 import {useSearch} from 'lib/useSearch';
 import {GetStaticPaths, GetStaticProps} from 'next';
 import React from 'react';
-import Post from 'types/post';
 import SearchContent from 'types/searchContent';
 
 type Props = {
-  post: Post;
+  title: string;
   content: string;
   searchContent: SearchContent;
 };
 
-export default function Page({post, content, searchContent}: Props) {
+export default function Page({title, content, searchContent}: Props) {
   useSearch(searchContent);
   return (
     <div>
+      <Title pageTitle={title} />
       <MarkdownArticle content={content} />
     </div>
   );
@@ -38,7 +39,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 
   return {
     props: {
-      post,
+      title: post.title,
       content,
       searchContent,
     },

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -3,6 +3,7 @@ import Post from 'types/post';
 import PostSummary from 'components/PostSummary';
 import {getAllPosts} from 'lib/postMarkdown';
 import Prose from 'components/Prose';
+import Title from 'components/Title';
 
 type Props = {
   posts: Post[];
@@ -11,6 +12,7 @@ type Props = {
 export default function Posts({posts}: Props) {
   return (
     <div>
+      <Title pageTitle="Posts" />
       <Prose>
         <h1>Posts</h1>
       </Prose>
@@ -19,6 +21,7 @@ export default function Posts({posts}: Props) {
           .filter(post => !(post.draft ?? false))
           .map(post => (
             <PostSummary
+              key={post.title}
               title={post.title}
               author={post.author}
               date={post.date}


### PR DESCRIPTION
- Creates a `Title` component that can be added to any page and change it's title.
- Adds this to all pages except the index, which will just have the default LDaCA title. 
- Did the same for ATAP but pushed it already